### PR TITLE
Use v7.6 insert on whmcs 8

### DIFF
--- a/dondominio_mod_tlds_new.php
+++ b/dondominio_mod_tlds_new.php
@@ -419,7 +419,7 @@ function dondominio_mod_tlds_create( $vars )
 			$authcode = ( $authcode_required == 1 ) ? 'on' : '';
 			
 			if ( (int) dd_get_whmcs_version() >= 7 ) {
-                if ( (int) dd_get_whmcs_sub_version() >= 6 ) {
+                if ( (int) dd_get_whmcs_sub_version() >= 6 || (int) dd_get_whmcs_version() == 8) {
                     $s_insert = "
 						INSERT INTO tbldomainpricing
 						VALUES (


### PR DESCRIPTION
We should use the same insert to the database for whmcs version 8 that the one we use on whmcs > 7.6.
Previous if would make use the older method, as for now dd_get_whmcs_sub_version() is null. 
Can also be aproached by making the check for it bigger than 7, so that it can be available for newer versions, but this can also break those newer versions that haven't been compatibility checked.

ISSUE #5 